### PR TITLE
Depollute rake global scope

### DIFF
--- a/lib/tasks/tracking.rake
+++ b/lib/tasks/tracking.rake
@@ -1,10 +1,28 @@
 # frozen_string_literal: true
 
+module IronTrail::RakeHelper
+  class << self
+    def db_functions
+      IronTrail::DbFunctions.new(ActiveRecord::Base.connection)
+    end
+
+    def abort_when_unsafe!
+      run_unsafe = %w[true 1 yes].include?(ENV['IRONTRAIL_RUN_UNSAFE'])
+      return unless Rails.env.production? && !run_unsafe
+
+      puts "Aborting: operation is dangerous in a production environment. " + \
+            "Override this behavior by setting the IRONTRAIL_RUN_UNSAFE=1 env var."
+
+      exit(1)
+    end
+  end
+end
+
 namespace :iron_trail do
   namespace :tracking do
     desc 'Enables tracking for all missing tables.'
     task enable: :environment do
-      tables = db_functions.collect_tables_tracking_status[:missing]
+      tables = IronTrail::RakeHelper.db_functions.collect_tables_tracking_status[:missing]
       unless tables.length > 0
         puts "All tables are being tracked already (no missing tables found)."
         puts "If you think this is wrong, check your ignored_tables list."
@@ -13,21 +31,21 @@ namespace :iron_trail do
 
       puts "Will start tracking #{tables.length} tables."
       tables.each do |table_name|
-        db_functions.enable_tracking_for_table(table_name)
+        IronTrail::RakeHelper.db_functions.enable_tracking_for_table(table_name)
       end
     end
 
     desc 'Disables tracking all tables. Dangerous!'
     task disable: :environment do
-      abort_when_unsafe!
+      IronTrail::RakeHelper.abort_when_unsafe!
 
-      tables = db_functions.collect_tables_tracking_status[:tracked]
+      tables = IronTrail::RakeHelper.db_functions.collect_tables_tracking_status[:tracked]
       puts "Will stop tracking #{tables.length} tables."
       tables.each do |table_name|
-        db_functions.disable_tracking_for_table(table_name)
+        IronTrail::RakeHelper.db_functions.disable_tracking_for_table(table_name)
       end
 
-      tables = db_functions.collect_tables_tracking_status[:tracked]
+      tables = IronTrail::RakeHelper.db_functions.collect_tables_tracking_status[:tracked]
       if tables.length > 0
         puts "WARNING: Something went wrong. There are still #{tables.length}" + \
              " tables being tracked."
@@ -38,7 +56,7 @@ namespace :iron_trail do
 
     desc 'Shows which tables are tracking, missing and ignored.'
     task status: :environment do
-      status = db_functions.collect_tables_tracking_status
+      status = IronTrail::RakeHelper.db_functions.collect_tables_tracking_status
       ignored = (IronTrail.config.ignored_tables || [])
 
       # We likely want to keep this structure of text untouched as someone
@@ -61,22 +79,6 @@ namespace :iron_trail do
       ignored.sort.each do |table_name|
         puts "\t#{table_name}"
       end
-    end
-
-    private
-
-    def db_functions
-      @db_functions ||= IronTrail::DbFunctions.new(ActiveRecord::Base.connection)
-    end
-
-    def abort_when_unsafe!
-      run_unsafe = %w[true 1 yes].include?(ENV['IRONTRAIL_RUN_UNSAFE'])
-      return unless Rails.env.production? && !run_unsafe
-
-      puts "Aborting: operation is dangerous in a production environment. " + \
-            "Override this behavior by setting the IRONTRAIL_RUN_UNSAFE=1 env var."
-
-      exit(1)
     end
   end
 end


### PR DESCRIPTION
Defining funtions in rake tasks affects the global rake scope (!!!).

The changes in this PR is one way I found to avoid that pollution.