### PR TITLE
Allow disabling ignored tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Added means to disable tracking ignored tables
+
+## 0.0.1 - 2024-11-26
+
+Initial release.

--- a/lib/iron_trail/db_functions.rb
+++ b/lib/iron_trail/db_functions.rb
@@ -83,6 +83,18 @@ module IronTrail
       end
     end
 
+    def disable_for_all_ignored_tables
+      affected_tables = collect_tracked_table_names & (
+        OWN_TABLES + (IronTrail.config.ignored_tables || [])
+      )
+
+      affected_tables.each do |table_name|
+        disable_tracking_for_table(table_name)
+      end
+
+      affected_tables
+    end
+
     def collect_tables_tracking_status
       ignored_tables = OWN_TABLES + (IronTrail.config.ignored_tables || [])
 

--- a/lib/tasks/tracking.rake
+++ b/lib/tasks/tracking.rake
@@ -35,6 +35,19 @@ namespace :iron_trail do
       end
     end
 
+    desc 'Disabled tracking for any ignored table that might still have the trigger enabled.'
+    task disable_on_ignored: :environment do
+      affected_tables = IronTrail::RakeHelper.db_functions.disable_for_all_ignored_tables
+
+      unless affected_tables.empty?
+        puts "Removed tracking from #{affected_tables.length} tables:"
+
+        affected_tables.each do |table_name|
+          puts "\t#{table_name}"
+        end
+      end
+    end
+
     desc 'Disables tracking all tables. Dangerous!'
     task disable: :environment do
       IronTrail::RakeHelper.abort_when_unsafe!

--- a/spec/iron_trail/db_functions_spec.rb
+++ b/spec/iron_trail/db_functions_spec.rb
@@ -117,6 +117,24 @@ RSpec.describe IronTrail::DbFunctions do
     end
   end
 
+  describe '#disable_for_all_ignored_tables' do
+    subject(:disable_it!) do
+      instance.disable_for_all_ignored_tables
+    end
+
+    context 'when no ignored tables are tracked' do
+      it 'returns an empty array' do
+        expect(disable_it!).to eq([])
+      end
+
+      it 'does not call disable_tracking_for_table' do
+        expect(instance).to receive(:disable_tracking_for_table).exactly(0).times
+
+        disable_it!
+      end
+    end
+  end
+
   describe 'function creation and removal' do
     context 'with default setup' do
       it 'has the function present' do


### PR DESCRIPTION
[Jira task](https://trusted-health.atlassian.net/browse/FND-3418)

This implements a method `#disable_for_all_ignored_tables` that will disable tracking on all ignored tables. It does nothing if there are no ignores tables being tracked.

A handy rake task is also added that calls that method. This allows one to easily untrack tables with the following process:

1. Call `rake iron_trail:tracking:disable_on_ignored` on every deploy, e.g. together with `rake db:migrate`
2. Allow engineers to add ignored tables to the `IronTrail.config.ignored_tables` config in the IronTrail initializer file and not have to worry about applying the changes -- of course they'd still have to worry about deleting tracked data if that's desired.