### PR TITLE
Bugfix: implement #macro in IronTrail::Reflection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `ActiveRecord::Reflection#reflect_on_all_associations` would not work for models having IronTrail enabled
+
 ### Added
 
 - Now able to travel back in time with `model.iron_trails.travel_to(some_timestamp)`

--- a/lib/iron_trail/reflection.rb
+++ b/lib/iron_trail/reflection.rb
@@ -4,6 +4,8 @@ module IronTrail
   class Reflection < ::ActiveRecord::Reflection::AssociationReflection
     def collection?; true; end
 
+    def macro; :has_iron_trails; end
+
     def association_class
       ::IronTrail::Association
     end

--- a/spec/services/people_manager_spec.rb
+++ b/spec/services/people_manager_spec.rb
@@ -15,7 +15,26 @@ RSpec.describe PeopleManager do
       record_new = JSON.parse(results.first['rec_new'])
       expect(record_new).to eq(person.as_json)
     end
+  end
 
+  describe 'rails model reflection' do
+    it 'lists the IronTrail reflection in a model' do
+      all_reflections = Person.reflect_on_all_associations
+      only_irontrail = all_reflections.select { |refl| IronTrail::Reflection === refl }
+
+      expect(all_reflections.length).to eq(3)
+      expect(only_irontrail.length).to eq(1)
+    end
+
+    it 'is able to list specific reflections' do
+      belongs_to_reflections = Person.reflect_on_all_associations(:belongs_to)
+      expect(belongs_to_reflections.length).to eq(1)
+    end
+
+    it 'is able to list only IronTrail reflections' do
+      irontrail_reflections = Person.reflect_on_all_associations(:has_iron_trails)
+      expect(irontrail_reflections.length).to eq(1)
+    end
   end
 
   describe '#employ_classic_guitars' do


### PR DESCRIPTION
[Jira task](https://trusted-health.atlassian.net/browse/FND-3454)

Essentially, calling `SomeModel.reflect_on_all_associations(:belongs_to)` (or with any other argument other than `nil`) fails because IronTrail::Reflection doesn't define the `macro` method, even though it can't yet be defined via a macro.

Kudos to @cuzik for the bug report and providing the fix!