### PR TITLE
`#travel_to` nil-check + bump to 0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.0.5 - 2025-01-06
+
+### Fixed
+
+- `#travel_to` now returns nil when no versions are found in the specified timestamp.
+
 ## 0.0.4 - 2024-12-30
 
 ### Added

--- a/lib/iron_trail/collection_proxy_mixin.rb
+++ b/lib/iron_trail/collection_proxy_mixin.rb
@@ -10,7 +10,7 @@ module IronTrail
         .where(arel_table[:created_at].lteq(ts))
         .first
 
-      change_record.reify
+      change_record&.reify
     end
   end
 end

--- a/lib/iron_trail/version.rb
+++ b/lib/iron_trail/version.rb
@@ -1,5 +1,5 @@
 # frozen_literal_string: true
 
 module IronTrail
-  VERSION = '0.0.4'
+  VERSION = '0.0.5'
 end


### PR DESCRIPTION
Hi, just adding a nil-check to prevent `#travel_to` from breaking when there are no versions in the specified timeframe. We may need to think how the `#travel_to` should work, but for now I'd suggest to return nil.