### PR TITLE
Use model timestamps when available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use model timestamps (created_at, updated_at) for irontrail_changes.created_at column
+
 ## 0.0.6 - 2025-01-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Enabling/disabling IronTrail in specs works by replacing the trigger function in
 with a dummy no-op function or with the real function and it won't add or drop triggers from
 any tables.
 
+The `created_at` column of the `irontrail_changes` table is determined from the model timestamp attributes
+(`created_at` for inserts and `updated_at` for updates) if they're present.
+There is a caveat for delete operations: the value will always be the current timestamp from the database. This makes it impossible to mock for that scenario.
+
 ## Rake tasks
 
 IronTrail comes with a few handy rake tasks you can use in your dev, test and

--- a/lib/iron_trail/irontrail_log_row_function.sql
+++ b/lib/iron_trail/irontrail_log_row_function.sql
@@ -34,9 +34,9 @@ BEGIN
     new_obj = row_to_json(NEW);
 
     IF (TG_OP = 'INSERT' AND new_obj ? 'created_at') THEN
-      created_at = (new_obj->>'created_at')::timestamp;
+      created_at = NEW.created_at;
     ELSIF (TG_OP = 'UPDATE' AND new_obj ? 'updated_at') THEN
-      created_at = (new_obj->>'updated_at')::timestamp;
+      created_at = NEW.updated_at;
     END IF;
 
     IF (created_at IS NULL) THEN

--- a/lib/iron_trail/irontrail_log_row_function.sql
+++ b/lib/iron_trail/irontrail_log_row_function.sql
@@ -41,6 +41,8 @@ BEGIN
 
     IF (created_at IS NULL) THEN
       created_at = NOW();
+    ELSE
+      it_meta_obj = jsonb_set(COALESCE(it_meta_obj, '{}'::jsonb), array['_db_created_at'], TO_JSONB(NOW()));
     END IF;
 
     IF (TG_OP = 'INSERT') THEN

--- a/lib/iron_trail/irontrail_log_row_function.sql
+++ b/lib/iron_trail/irontrail_log_row_function.sql
@@ -11,10 +11,12 @@ DECLARE
   new_obj JSONB;
   actor_type TEXT;
   actor_id TEXT;
+  created_at TIMESTAMP;
 
   err_text TEXT; err_detail TEXT; err_hint TEXT; err_ctx TEXT;
 BEGIN
     SELECT split_part(split_part(current_query(), '/*IronTrail ', 2), ' IronTrail*/', 1) INTO it_meta;
+
     IF (it_meta <> '') THEN
       it_meta_obj = it_meta::JSONB;
 
@@ -28,17 +30,28 @@ BEGIN
       END IF;
     END IF;
 
+    old_obj = row_to_json(OLD);
+    new_obj = row_to_json(NEW);
+
+    IF (TG_OP = 'INSERT' AND new_obj ? 'created_at') THEN
+      created_at = (new_obj->>'created_at')::timestamp;
+    ELSIF (TG_OP = 'UPDATE' AND new_obj ? 'updated_at') THEN
+      created_at = (new_obj->>'updated_at')::timestamp;
+    END IF;
+
+    IF (created_at IS NULL) THEN
+      created_at = NOW();
+    END IF;
+
     IF (TG_OP = 'INSERT') THEN
         INSERT INTO "irontrail_changes" ("actor_id", "actor_type",
           "rec_table", "operation", "rec_id", "rec_new", "metadata", "created_at")
         VALUES (actor_id, actor_type,
-          TG_TABLE_NAME, 'i', NEW.id, row_to_json(NEW), it_meta_obj, NOW());
+          TG_TABLE_NAME, 'i', NEW.id, new_obj, it_meta_obj, created_at);
 
     ELSIF (TG_OP = 'UPDATE') THEN
         IF (OLD <> NEW) THEN
           u_changes = jsonb_build_object();
-          old_obj = row_to_json(OLD);
-          new_obj = row_to_json(NEW);
 
           FOR key IN (SELECT jsonb_object_keys(old_obj) UNION SELECT jsonb_object_keys(new_obj))
           LOOP
@@ -51,14 +64,13 @@ BEGIN
 
           INSERT INTO "irontrail_changes" ("actor_id", "actor_type", "rec_table", "operation",
             "rec_id", "rec_old", "rec_new", "rec_delta", "metadata", "created_at")
-          VALUES (actor_id, actor_type, TG_TABLE_NAME, 'u', NEW.id, row_to_json(OLD), row_to_json(NEW),
-          u_changes, it_meta_obj, NOW());
+          VALUES (actor_id, actor_type, TG_TABLE_NAME, 'u', NEW.id, old_obj, new_obj, u_changes, it_meta_obj, created_at);
 
         END IF;
     ELSIF (TG_OP = 'DELETE') THEN
         INSERT INTO "irontrail_changes" ("actor_id", "actor_type", "rec_table", "operation",
           "rec_id", "rec_old", "metadata", "created_at")
-        VALUES (actor_id, actor_type, TG_TABLE_NAME, 'd', OLD.id, row_to_json(OLD), it_meta_obj, NOW());
+        VALUES (actor_id, actor_type, TG_TABLE_NAME, 'd', OLD.id, old_obj, it_meta_obj, created_at);
 
     END IF;
     RETURN NULL;

--- a/spec/dummy_app/app/models/guitar_part.rb
+++ b/spec/dummy_app/app/models/guitar_part.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 class GuitarPart < ApplicationRecord
+  include IronTrail::Model
+
   belongs_to :guitar
 end

--- a/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
+++ b/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
@@ -18,6 +18,8 @@ class SetupTestDb < ::ActiveRecord::Migration::Current
     create_table :guitar_parts, id: :bigserial, force: true do |t|
       t.uuid :guitar_id
       t.string :name
+
+      t.timestamps
     end
 
     create_table :matrix_pills, id: :bigserial, force: true do |t|

--- a/spec/models/guitar_spec.rb
+++ b/spec/models/guitar_spec.rb
@@ -61,6 +61,21 @@ RSpec.describe Guitar do
       expect(oldest_trail.id).to eq(trails[1].id)
     end
 
+    describe 'record insertion' do
+      let(:fake_insert_time) { '2021-12-14T12:34:56.010102Z' }
+
+      it 'uses the model creation time for the insert operation' do
+        part = nil
+
+        travel_to(fake_insert_time) do
+          part = guitar.guitar_parts.create!(name: 'neck')
+        end
+
+        trail = part.iron_trails.first
+        expect(trail.created_at).to be_within(1.second).of(Time.parse(fake_insert_time))
+      end
+    end
+
     describe 'record deletion' do
       let(:fake_delete_time) { '2023-01-22T23:24:25.262728Z' }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,4 +43,5 @@ require_relative 'support/iron_trail_spec_migrator'
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
+  config.include ActiveSupport::Testing::TimeHelpers
 end


### PR DESCRIPTION

It changes how the value for `created_at` column in `irontrail_changes` rows is determined. Originally, it was just set to whatever postgres's `NOW()` function would return. This changes it so that it considers the models' timestamp attributes (`created_at` and `updated_at`). Note: it doesn't account for `*_on` or other name variations for timestamps.

The logic is the following:

1. When inserting a record, it tries to use the value of the `created_at` column. Otherwise*, it uses the value of `NOW()`.
1. When updating a record, it tries to use the value of the `updated_at` column. Otherwise*, it uses the value of `NOW()`.
1. When deleting a record, it just uses the value of `NOW()`.

----


Related tasks:
- [INF-234](https://app.asana.com/0/1209094583406668/1209213135038824/f)

This is an alternative to https://github.com/trusted/iron_trail/pull/17 -- there could be a hybrid of both, but I feel for now let's take the simpler route of this PR only. The only "odd" case is that it would be harder to determine the creation date of `irontrail_changes` records in a test environment, since there's no way to mock it. But I understand that the way it is covers most uses cases with less overall complexity, while still preserving a predictable and good behavior in production environments.