### PR TITLE
Add a way to monitor error metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `IronTrail::DbFunctions#trigger_errors_metrics` method to be able to monitor error metrics
+
 ## 0.1.0 - 2025-01-29
 
 ### Changed

--- a/spec/iron_trail/db_functions_spec.rb
+++ b/spec/iron_trail/db_functions_spec.rb
@@ -117,6 +117,34 @@ RSpec.describe IronTrail::DbFunctions do
     end
   end
 
+  describe '#trigger_errors_metrics' do
+    subject(:metrics) { instance.trigger_errors_metrics }
+
+    it 'is has zero values when there are no trigger errors' do
+      expect(metrics).to be_a(Hash)
+      expect(metrics).to eq({
+        max_created_at: 0,
+        max_id: 0,
+      })
+    end
+
+    context 'when there are trigger errors' do
+      before do
+        connection.execute(<<~SQL)
+        INSERT INTO "irontrail_trigger_errors" (id, query, created_at) VALUES
+          (42, 'foo', '2023-06-15T12:01:03Z');
+        SQL
+      end
+
+      it 'matches the max created_at and ids' do
+        expect(metrics).to eq({
+          max_id: 42,
+          max_created_at: Time.parse('2023-06-15T12:01:03Z').to_i,
+        })
+      end
+    end
+  end
+
   describe '#disable_for_all_ignored_tables' do
     subject(:disable_it!) do
       instance.disable_for_all_ignored_tables


### PR DESCRIPTION
This adds the `trigger_errors_metrics` method that can be used like:

```ruby
fun = IronTrail::DbFunctions.new(ActiveRecord::Base.connection)
metrics = fun.trigger_errors_metrics

timestamp_threshold = Time.parse('Tue Feb  4 09:47:02 UTC 2025')
if metrics[:max_created_at] > timestamp_threshold.to_i
  register_an_alert_somewhere(
    "WARNING! There is a new iron_trail error recorded since #{timestamp_threshold}"
  )
end

threshold_error_id = 0 # a good goal is to keep irontrail_trigger_errors table empty
if metrics[:max_id] > threshold_error_id
  register_an_alert_somewhere(
    "WARNING! There is a new iron_trail error recorded! Please inspect and delete data from irontrail_trigger_errors"
  )
end
```

This allows one to have monitoring and alerting for errors that might occur in the trigger function (that big PL/pgSQL code).

Note that errors reported to `irontrail_trigger_errors` can be reverted back into actual data in the `irontrail_changes` table. That would require manual effort to process and move the data, but it'd be very rare to have any data lost. Since this migration process might take a while (many hours or days), it may be that the errors table contains data for longer periods of time, so having flexible alert thresholds would be handy, but this is very much specific to each company and product :)

-------

[INF-184](https://app.asana.com/0/1209094583406668/1209095867326165)