### PR TITLE
Bugfix: use updated_at only if it has changed

### DIFF
--- a/lib/iron_trail/irontrail_log_row_function.sql
+++ b/lib/iron_trail/irontrail_log_row_function.sql
@@ -36,7 +36,9 @@ BEGIN
     IF (TG_OP = 'INSERT' AND new_obj ? 'created_at') THEN
       created_at = NEW.created_at;
     ELSIF (TG_OP = 'UPDATE' AND new_obj ? 'updated_at') THEN
-      created_at = NEW.updated_at;
+      IF (NEW.updated_at <> OLD.updated_at) THEN
+        created_at = NEW.updated_at;
+      END IF;
     END IF;
 
     IF (created_at IS NULL) THEN

--- a/spec/models/guitar_spec.rb
+++ b/spec/models/guitar_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe Guitar do
       expect(trails[2].created_at).to be_within(1.second).of(some_part.updated_at)
     end
 
+    context 'when an object is updated without changing the updated_at column' do
+      let(:second_fake_updated_at) { 10.seconds.ago }
+
+      before do
+        travel_to(second_fake_updated_at) do
+          some_part.update!(name: 'Neck of the Guitar')
+        end
+
+        some_part.update_columns(name: 'Part of the Guitar')
+      end
+
+      it 'creates the irontrail_change with the current DB timestamp' do
+        expect(trails).to have_attributes(count: 5)
+        expect(trails[-2].created_at).to be_within(1.second).of(second_fake_updated_at)
+        expect(trails[-1].created_at).to be_within(1.second).of(Time.now)
+      end
+    end
+
     it 'will logically have the oldest trail be the first update' do
       oldest_trail = some_part.iron_trails.order(created_at: :asc).first
       expect(oldest_trail.id).to eq(trails[1].id)


### PR DESCRIPTION
When a record whose table has the `updated_at` column is updated but without touching the `updated_at` column (e.g. when using callback-skipping AR methods like `update_column`), `irontrail_changes` records will be created in the past, always with a fixed `updated_at` value.

This is a bug which this PR addresses. The fix changes the trigger function to check if the `updated_at` column was changed (by comparing old vs new values) on an `UPDATE` SQL operation. If `updated_at` didn't change but there was an update, then use the current DB timestamp instead of the record `updated_at`.


---------

[Asana INF-267](https://app.asana.com/0/1209094583406668/1209351251955407)