### PR TITLE
Add with_delta_other_than

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add '.with_delta_other_than' to `IronTrail::ChangeModelConcern`
+
 ## 0.1.4 - 2025-02-24
 
 ### Fixed


### PR DESCRIPTION
Adds a `.with_delta_other_than` scope that allows one to do something like:

```ruby
person = Person.find(42)
person.update(name: 'Bob')
person.touch

changes = person.iron_trails
changes.count # => 3 (1 insert + 2 updates)

changes person.iron_trails.with_delta_other_than(:updated_at)
changes.count # => 1 (there is only one update that changes more columsn other than the updated_at one)
```

-------

This work is part of [INF-256](https://app.asana.com/0/1209094583406668/1209334903098783/f)