### PR TITLE
Do not exclude non-updates in with_delta_other_than

### DIFF
--- a/lib/iron_trail/change_model_concern.rb
+++ b/lib/iron_trail/change_model_concern.rb
@@ -29,14 +29,12 @@ module IronTrail
       #
       # This works by inspecting whether there are any keys in the rec_delta column
       # other than the columns specified in the `columns` parameter.
-      #
-      # Caveats: this implicitly filters out insert and delete operations, because
-      #   rec_delta would be null in such cases.
       def with_delta_other_than(*columns)
         quoted_columns = columns.map { |col_name| connection.quote(col_name) }
         exclude_array = "ARRAY[#{quoted_columns.join(', ')}]::text[]"
 
-        where(::Arel::Nodes::SqlLiteral.new("(rec_delta - #{exclude_array}) <> '{}'::jsonb"))
+        sql = "rec_delta IS NULL OR (rec_delta - #{exclude_array}) <> '{}'::jsonb"
+        where(::Arel::Nodes::SqlLiteral.new(sql))
       end
 
       private


### PR DESCRIPTION
The fact that `with_delta_other_than` makes the implicit change to filter by only update operations makes it problematic. This PR changes this so that it includes any kind of operation. For inserts and deletes, for which `rec_delta` is always NULL, it ignores that column.

This changes the behavior introduced in https://github.com/trusted/iron_trail/pull/28