### PR TITLE
[INF-416] [INF-230] Fix timezone and method calling issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Call `IronTrail::Current.reset` before each spec when using `iron_trail/testing/rspec`
+- Attributes in iron trails won't try to set attributes via send("#{attr_name}=") anymore
+
+### Fixed
+
+- Timestamps are reified correctly when the rails app uses a non-UTC time zone
 
 ## 0.1.4 - 2025-02-24
 

--- a/lib/iron_trail/reifier.rb
+++ b/lib/iron_trail/reifier.rb
@@ -8,12 +8,10 @@ module IronTrail
 
       record = klass.where(id: trail.rec_id).first || klass.new
 
-      source_attributes.each do |name, serialized_value|
-        attr_type = record.type_for_attribute(name)
-        value = attr_type.deserialize(serialized_value)
-
+      source_attributes.each do |name, value|
         if record.has_attribute?(name)
-          record[name] = value
+          attr_type = record.type_for_attribute(name)
+          record[name] = attr_type.deserialize(value)
         else
           ghost = record.instance_variable_get(:@irontrail_reified_ghost_attributes)
           unless ghost

--- a/lib/iron_trail/reifier.rb
+++ b/lib/iron_trail/reifier.rb
@@ -8,9 +8,12 @@ module IronTrail
 
       record = klass.where(id: trail.rec_id).first || klass.new
 
-      source_attributes.each do |name, value|
+      source_attributes.each do |name, serialized_value|
+        attr_type = record.type_for_attribute(name)
+        value = attr_type.deserialize(serialized_value)
+
         if record.has_attribute?(name)
-          record[name.to_sym] = value
+          record[name] = value
         elsif record.respond_to?("#{name}=")
           record.send("#{name}=", value)
         else

--- a/lib/iron_trail/reifier.rb
+++ b/lib/iron_trail/reifier.rb
@@ -14,8 +14,6 @@ module IronTrail
 
         if record.has_attribute?(name)
           record[name] = value
-        elsif record.respond_to?("#{name}=")
-          record.send("#{name}=", value)
         else
           ghost = record.instance_variable_get(:@irontrail_reified_ghost_attributes)
           unless ghost

--- a/spec/dummy_app/app/models/hotel.rb
+++ b/spec/dummy_app/app/models/hotel.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Hotel < ApplicationRecord
+  include IronTrail::Model
+end

--- a/spec/dummy_app/app/models/hotel.rb
+++ b/spec/dummy_app/app/models/hotel.rb
@@ -2,4 +2,9 @@
 
 class Hotel < ApplicationRecord
   include IronTrail::Model
+
+  has_one :owner_person,
+    class_name: 'Person',
+    inverse_of: :owns,
+    dependent: :destroy
 end

--- a/spec/dummy_app/app/models/person.rb
+++ b/spec/dummy_app/app/models/person.rb
@@ -4,10 +4,16 @@ class Person < ApplicationRecord
   include IronTrail::Model
 
   has_many :guitars
+
   belongs_to :converted_by_pill,
     optional: true,
     polymorphic: true,
     class_name: 'MatrixPill'
+
+  belongs_to :owns,
+    class_name: 'Hotel',
+    foreign_key: :owns_the_hotel,
+    optional: true
 
   def full_name
     "#{first_name} #{last_name}"

--- a/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
+++ b/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
@@ -20,7 +20,7 @@ class SetupTestDb < ::ActiveRecord::Migration::Current
       t.string :name
       t.timestamp :hotel_time
       t.timestamptz :time_in_japan
-      t.date :opening_day
+      t.jsonb :room_map
     end
 
     create_table :guitar_parts, id: :bigserial, force: true do |t|

--- a/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
+++ b/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
@@ -18,8 +18,8 @@ class SetupTestDb < ::ActiveRecord::Migration::Current
 
     create_table :hotels, id: :bigserial, force: true do |t|
       t.string :name
-      t.timestamp :current_time
-      t.timestamp :time_in_japan
+      t.timestamp :hotel_time
+      t.timestamptz :time_in_japan
       t.date :opening_day
     end
 

--- a/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
+++ b/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
@@ -7,12 +7,20 @@ class SetupTestDb < ::ActiveRecord::Migration::Current
       t.string :last_name, null: false
       t.string :favorite_planet
       t.bigint :converted_by_pill_id
+      t.bigint :preferred_hotel_id
       t.timestamp :first_acquired_guitar_at
     end
 
     create_table :guitars, id: :uuid, force: true do |t|
       t.bigint :person_id, null: false
       t.string :description, null: false
+    end
+
+    create_table :hotels, id: :bigserial, force: true do |t|
+      t.string :name
+      t.timestamp :current_time
+      t.timestamp :time_in_japan
+      t.date :opening_day
     end
 
     create_table :guitar_parts, id: :bigserial, force: true do |t|

--- a/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
+++ b/spec/dummy_app/db/migrate/20241112090542_setup_test_db.rb
@@ -7,7 +7,7 @@ class SetupTestDb < ::ActiveRecord::Migration::Current
       t.string :last_name, null: false
       t.string :favorite_planet
       t.bigint :converted_by_pill_id
-      t.bigint :preferred_hotel_id
+      t.bigint :owns_the_hotel
       t.timestamp :first_acquired_guitar_at
     end
 

--- a/spec/iron_trail/db_functions_spec.rb
+++ b/spec/iron_trail/db_functions_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe IronTrail::DbFunctions do
       guitars
       matrix_pills
       people
+      hotels
     ]
   end
 

--- a/spec/models/hotel_spec.rb
+++ b/spec/models/hotel_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+RSpec.describe Hotel do
+  before do
+    sql = <<~SQL
+    SELECT setval('hotels_id_seq'::regclass, 5000, 't');
+
+    INSERT INTO hotels (id, name, hotel_time, time_in_japan, opening_day) VALUES
+      (100, 'Wonky', '2023-04-25 13:22:54.833 -0700', '2023-07-23 21:22:55.021 +9:00', '1998-03-18');
+
+    INSERT INTO hotels (id, name, hotel_time, time_in_japan, opening_day) VALUES (200, 'Blurry', '2023-04-25 13:22:54.833 -7:00', '2023-07-23 21:22:55.021 +9:00', '1998-03-18');
+
+    UPDATE hotels SET hotel_time='2023-10-12 14:18:29.422', time_in_japan='2023-10-13T17:16:15.021+0200' WHERE id=100;
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+
+  let(:hotel) { Hotel.find(100) }
+  let(:ordered_trails) { hotel.iron_trails.order(id: :asc) }
+  let(:app_time_zone) { 'America/Santiago' }
+
+  it 'is sane' do
+    expect(ordered_trails).to have_attributes(count: 2)
+  end
+
+  describe 'timestamp WITHOUT time zone column' do
+    before { hotel }
+
+    it 'deserializes correctly' do
+      original_hotel = in_time_zone(app_time_zone) do
+        ordered_trails.first.reify
+      end
+
+      utc_zone = ActiveSupport::TimeZone['UTC'] # +00:00
+      jp_zone = ActiveSupport::TimeZone['Tokyo'] # +09:00
+
+      original_time_utc = utc_zone.local(2023, 4, 25, 13, 22, 54, 833000)
+      current_time_utc = utc_zone.local(2023, 10, 12, 14, 18, 29, 422000)
+
+      expect(original_hotel.hotel_time).to eq(original_time_utc)
+      expect(hotel.hotel_time).to eq(current_time_utc)
+    end
+  end
+
+  describe 'timestamp WITH time zone column' do
+    it 'deserializes correctly' do
+      original_hotel = in_time_zone(app_time_zone) do
+        ordered_trails.first.reify
+      end
+
+      jp_zone = ActiveSupport::TimeZone['Tokyo'] # +09:00
+      de_zone = ActiveSupport::TimeZone['Europe/Berlin'] # +02:00
+
+      original_japan_time = jp_zone.local(2023, 7, 23, 21, 22, 55, 21000)
+      current_japan_time = de_zone.local(2023, 10, 13, 17, 16, 15, 21000)
+
+      expect(original_hotel.time_in_japan).to eq(original_japan_time)
+      expect(hotel.time_in_japan).to eq(current_japan_time)
+    end
+  end
+
+  private
+
+  def in_time_zone(new_tz)
+    original_tz = Time.zone
+    begin
+      Time.zone = new_tz
+
+      yield
+    ensure
+      Time.zone = original_tz
+    end
+  end
+end

--- a/spec/models/hotel_spec.rb
+++ b/spec/models/hotel_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe Hotel do
     INSERT INTO hotels (id, name, hotel_time, time_in_japan, opening_day) VALUES
       (100, 'Wonky', '2023-04-25 13:22:54.833 -0700', '2023-07-23 21:22:55.021 +9:00', '1998-03-18');
 
-    INSERT INTO hotels (id, name, hotel_time, time_in_japan, opening_day) VALUES (200, 'Blurry', '2023-04-25 13:22:54.833 -7:00', '2023-07-23 21:22:55.021 +9:00', '1998-03-18');
-
     UPDATE hotels SET hotel_time='2023-10-12 14:18:29.422', time_in_japan='2023-10-13T17:16:15.021+0200' WHERE id=100;
     SQL
 

--- a/spec/services/people_manager_spec.rb
+++ b/spec/services/people_manager_spec.rb
@@ -22,13 +22,13 @@ RSpec.describe PeopleManager do
       all_reflections = Person.reflect_on_all_associations
       only_irontrail = all_reflections.select { |refl| IronTrail::Reflection === refl }
 
-      expect(all_reflections.length).to eq(3)
+      expect(all_reflections.length).to eq(4)
       expect(only_irontrail.length).to eq(1)
     end
 
     it 'is able to list specific reflections' do
       belongs_to_reflections = Person.reflect_on_all_associations(:belongs_to)
-      expect(belongs_to_reflections.length).to eq(1)
+      expect(belongs_to_reflections.length).to eq(2)
     end
 
     it 'is able to list only IronTrail reflections' do


### PR DESCRIPTION
This fixes two bugs when reifying iron trails.

When the rails app has a time zone configured that is not UTC, reifying `timestamp without time zone` columns would wrongly reify those with the app's current timestamp instead of UTC.

The other bug is actually a whole class of bugs which would stem from past trails being able to perform method calls in the model. Imagine that a `Hotel` model had a `owner_person` column in the past but doesn't have it anymore. If, for whatever reason, the Hotel class now has that defined as a setter method (`Hotel#owner_person=`) and someone tries to reify on a past version, it would call that setter.
That can be neat in some scenarios but can be destructive in others. This feature is being removed to respect the principle of least surprise. Non-column attributes can still be accessed through `IronTrail::Model#irontrail_reified_ghost_attributes` if needed.

This addresses:
- [INF-416](https://app.asana.com/1/303134204339906/project/1209094583406668/task/1210067884552125?focus=true)
- [INF-230](https://app.asana.com/1/303134204339906/project/1209169469993567/task/1209207181635935?focus=true)