### PR TITLE
Improve error reporting and spec coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Call `IronTrail::Current.reset` before each spec when using `iron_trail/testing/rspec`
 - Attributes in iron trails won't try to set attributes via send("#{attr_name}=") anymore
+- IronTrail::Current#merge_metadata now raises a proper error if argument is invalid
 
 ### Fixed
 

--- a/lib/iron_trail/current.rb
+++ b/lib/iron_trail/current.rb
@@ -10,6 +10,8 @@ module IronTrail
     end
 
     def self.merge_metadata(keys, merge_hash)
+      raise TypeError.new("value must be a Hash") unless merge_hash.is_a?(Hash)
+
       self.metadata ||= {}
       base = self.metadata
       keys.each do |key|

--- a/spec/iron_trail/current_spec.rb
+++ b/spec/iron_trail/current_spec.rb
@@ -2,10 +2,48 @@
 
 RSpec.describe IronTrail::Current do
   describe '.store_metadata' do
-    it 'stores a value in RequestStore' do
+    it 'stores a value in metadata' do
       described_class.store_metadata(:foo, 'bar')
 
       expect(described_class.metadata).to eq({ foo: 'bar' })
+    end
+
+    context 'when key already exists' do
+      before do
+        described_class.metadata = { foo: { qux: 42 } }
+      end
+
+      it 'replaces the key' do
+        described_class.store_metadata(:foo, { bottles: 99 })
+        expect(described_class.metadata).to eq({ foo: { bottles: 99 } })
+      end
+    end
+  end
+
+  describe '.merge_metadata' do
+    before do
+      described_class.metadata = {
+        foo: { qux: 42 },
+        bar: { xpto: -1 }
+      }
+    end
+
+    describe 'when specifying the key partially' do
+      it 'replaces the value' do
+        described_class.merge_metadata(%i[foo], { bottles: 99 })
+        expect(described_class.metadata).to eq({
+          foo: { bottles: 99, qux: 42 },
+          bar: { xpto: -1 }
+        })
+      end
+    end
+
+    describe 'when the second parameter is not a hash' do
+      it 'raises a TypeError' do
+        expect {
+          described_class.merge_metadata(%i[foo bottles], 99)
+        }.to raise_error(TypeError, /value must be a Hash/)
+      end
     end
   end
 end


### PR DESCRIPTION
`IronTrail::Current` doesn't have great spec coverage, especially the `#merge_metadata`method. This PR improves that.

It also changes the behavior of that method slightly by checking the second argument before doing any operations and raising an error if it isn't a hash.