### PR TITLE
Add changelog entry for 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.2.1 - 2026-03-05
+
+### Fixed
+
+- Fix unstable class resolution in Reifier.model_from_table_name
+
 ## 0.2.0 - 2026-02-27
 
 ### Added


### PR DESCRIPTION
## Summary

- Add changelog entry for version 0.2.1 documenting the fix for unstable class resolution in `Reifier.model_from_table_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)